### PR TITLE
Change dataType from json to text

### DIFF
--- a/chapters/cfprogressbar/index.md
+++ b/chapters/cfprogressbar/index.md
@@ -46,7 +46,7 @@ And now we call **getInterval** using AJAX :-
             strURL += 'method=' + method;
             $.ajax({
                 url: strURL,
-                dataType: 'json',
+                dataType: 'text',
                 success: function(response){
                     var currentValue = $("#progressbar").val();
                     var newValue = currentValue + response;


### PR DESCRIPTION
I always want to sync the dataType with the returnformat.  I think making them both json would actually work, and also leaving dataType out altogether might work since jQuery uses an "intelligent guess".
But if the function is returning a plain ole number, then I think the dataType should be text.
