### PR TITLE
Use cdn instead of downloading ckeditor

### DIFF
--- a/chapters/cftextarea/index.md
+++ b/chapters/cftextarea/index.md
@@ -65,7 +65,7 @@ And now the alternative to `<cftextarea>`.
             </div>
             #textarea_1#
         </cfoutput>
-        <script src="js/ckeditor/ckeditor.js"></script>
+        <script src="//cdn.ckeditor.com/4.4.3/standard/ckeditor.js"></script>
         <script type="text/javascript">
             CKEDITOR.replace('textarea_1');
         </script>


### PR DESCRIPTION
For someone trying to get ckeditor working the first time, using the cdn takes away the process of having to download it from ckeditor.com and upload it to their own server.
